### PR TITLE
webview loads links internally

### DIFF
--- a/src/edu/ggc/it/directory/DirectorySearchWebView.java
+++ b/src/edu/ggc/it/directory/DirectorySearchWebView.java
@@ -3,8 +3,10 @@ package edu.ggc.it.directory;
 
 import edu.ggc.it.R;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.app.Activity;
 import android.content.Intent;
@@ -22,7 +24,28 @@ public class DirectorySearchWebView extends Activity {
 		setContentView(R.layout.activity_directory_search_web_view);
 		mWebView = (WebView) findViewById(R.id.webView1);
         mWebView.getSettings().setJavaScriptEnabled(true);
+        mWebView.setWebViewClient(new WebViewClient() {
+            public boolean shouldOverrideUrlLoading(WebView view, String url){
+                // do your handling codes here, which url is the requested url
+                // probably you need to open that url rather than redirect:
+                view.loadUrl(url);
+                return false; // then it is not handled by default action
+           }
+            
+            
+        });
         mWebView.loadUrl(message);
 	}
-	
+	@Override
+	public boolean onKeyDown(int keyCode, KeyEvent event) {
+        // Check if the key event was the Back button and if there's history
+        if ((keyCode == KeyEvent.KEYCODE_BACK) && mWebView.canGoBack()) {
+            mWebView.goBack();
+            return true;
+        }
+        else {
+        	finish();
+        	return false;
+        }
+    }
 }


### PR DESCRIPTION
Good news:
What happens in the webview stays in the webview.
added code so you can navigate back through webview history.
Bad news:
clicking on phone number or email address currently wont start respective activites just returns a webpage not available. Have to work on an if the link is a certain type that opens an email client or dialer it starts those activities.
