### PR TITLE
menu change

### DIFF
--- a/res/menu/app_menu.xml
+++ b/res/menu/app_menu.xml
@@ -3,8 +3,7 @@
 
     <item
         android:id="@+id/More"
-        android:showAsAction="ifRoom|withText"
-        android:title="Menu">
+        android:title="More">
         <menu>
             <item
                 android:id="@+id/welcome"


### PR DESCRIPTION
I changed the menu to where it goes to action bar only if menu key isnt present. now when a user hits the menu key  itll pop up only one choice "More" which the user is then presented with a cleaner looking sub menu of choices. For devices without a menu key the action bar displays the 3 dots and upon clicking them are present with the "more" option too and drops down the menu list.
