### PR TITLE
Fix for widget and Rss feeds

### DIFF
--- a/src/edu/ggc/it/mainscreen/MainScreenSocialView.java
+++ b/src/edu/ggc/it/mainscreen/MainScreenSocialView.java
@@ -112,7 +112,7 @@ public class MainScreenSocialView extends LinearLayout implements View.OnClickLi
                             public void onClick(DialogInterface dialog,
                                                 int which) {
                                 Intent newsIntent = new Intent(context, RSSActivity.class);
-                                newsIntent.putExtra(RSSActivity.RSS_URL_EXTRA, RSS_URL.NEWS.toString());
+                                newsIntent.putExtra(RSSActivity.RSS_URL_EXTRA, RSS_URL.NEWS.URL());
                                 context.startActivity(newsIntent);
                             }
                         })
@@ -122,7 +122,7 @@ public class MainScreenSocialView extends LinearLayout implements View.OnClickLi
                             public void onClick(DialogInterface dialog,
                                                 int which) {
                                 Intent eventsIntent = new Intent(context, RSSActivity.class);
-                                eventsIntent.putExtra(RSSActivity.RSS_URL_EXTRA, RSS_URL.EVENTS.toString());
+                                eventsIntent.putExtra(RSSActivity.RSS_URL_EXTRA, RSS_URL.EVENTS.URL());
                                 context.startActivity(eventsIntent);
                             }
                         }).show();

--- a/src/edu/ggc/it/rss/RSSActivity.java
+++ b/src/edu/ggc/it/rss/RSSActivity.java
@@ -30,9 +30,12 @@ public class RSSActivity extends ListActivity implements RSSTaskComplete
 	super.onCreate(savedInstanceState);
 	setContentView(R.layout.rss);
 
+	String rssURL = getIntent().getStringExtra(RSS_URL_EXTRA);
 	context = this;
 	rssTask = new RSSTask(this, context, true);
-	rssTask.execute(setRSSActivityTitle(getIntent().getStringExtra(RSS_URL_EXTRA)));
+	rssTask.execute(getRSS_URL(rssURL));
+	
+	setRSSActivityTitle(rssURL);
 	adapter = new RSSAdapter(context);
     }
 
@@ -42,7 +45,25 @@ public class RSSActivity extends ListActivity implements RSSTaskComplete
      * @param rssURL		the URL passed as an extra 
      * @return url		RSS_URL that matches passed String
      */
-    private RSS_URL setRSSActivityTitle(String rssURL)
+    private void setRSSActivityTitle(String rssURL)
+    {
+	if(rssURL.equals(RSS_URL.NEWS.URL()))
+	{
+	    setTitle("GGC News");
+	}
+	else if(rssURL.equals(RSS_URL.EVENTS.URL()))
+	{
+	    setTitle("GGC Events");
+	}
+    }
+    
+    /**
+     * Returns an RSS_URL enum with the same URL as the passed String
+     * 
+     * @param rssURL		the URL passed as an extra
+     * @return url		RSS_URL that matches passed String
+     */
+    private RSS_URL getRSS_URL(String rssURL)
     {
 	RSS_URL[] urls = RSS_URL.values();
 	int index = 0;
@@ -50,7 +71,6 @@ public class RSSActivity extends ListActivity implements RSSTaskComplete
 	{
 	    if(rssURL.equals(urls[i].URL()))
 	    {
-		setTitle("GGC " + urls[i].title());
 		index = i;
 	    }
 	}
@@ -77,7 +97,7 @@ public class RSSActivity extends ListActivity implements RSSTaskComplete
     /**
      * Called when RSSTask finishes execution
      * 
-     * @param containers	container filled by RSSTask
+     * @param containers	containers filled by RSSTask
      */
     @Override
     public void taskComplete(RSSDataContainer[] containers)

--- a/src/edu/ggc/it/widget/WidgetService.java
+++ b/src/edu/ggc/it/widget/WidgetService.java
@@ -2,6 +2,7 @@ package edu.ggc.it.widget;
 
 import edu.ggc.it.R;
 import android.content.Intent;
+import android.util.Log;
 import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
@@ -13,6 +14,7 @@ import android.widget.RemoteViewsService;
  */
 public class WidgetService extends RemoteViewsService
 {
+    private static final String TAG = "WidgetService";
     /**
      * Returns a ViewsFactory object
      */
@@ -71,6 +73,9 @@ public class WidgetService extends RemoteViewsService
 	@Override
 	public RemoteViews getViewAt(int index)
 	{
+	    if(index < 0 || index >= getCount()) {
+		return null;
+	    }
 	    String title = data.getCurrentContainer().getTitleAt(index);
 	    rv.setTextViewText(R.id.widget_title_textview, title);
 	    


### PR DESCRIPTION
-The rss feeds were fairly simple to fix, I had forgotten to change a method call in MainScreenSocialView when I changed a method name in RSS_URL enum.
-The widget crash seemed to be caused by an IndexOutOfBoundsException, in WidgetService's getViewAt(int index) method, I added a check to make sure that this won't happen. The index value passed to the getViewAt() method is something that is handled by android so I just had to work around it. I found this forum post to someone that was having the same issue and they suggest it might be an android bug https://groups.google.com/forum/#!topic/android-developers/j8H0O8Wb0B8
